### PR TITLE
Persistent Configuration for file paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # CSVs that may be generated in the directory
 *.csv
+
+# profiling results
+fil-result/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+PySide2~=5.15.2.1
+ijson~=3.2.3
+platformdirs~=4.0.0


### PR DESCRIPTION
Add persistent configuration for the three file paths, to avoid having to select the Scryfall and Delver database every time the program is launched.

Should also be useful when the Moxfield option for export is added.